### PR TITLE
Keep changelog

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -130,7 +130,6 @@ svn update --quiet $SVNPATH/trunk --set-depth infinity
 
 echo "Ignoring GitHub specific files"
 svn propset svn:ignore "README.md
-CHANGELOG.md
 Thumbs.db
 .github/*
 .git

--- a/deploy.sh
+++ b/deploy.sh
@@ -77,11 +77,11 @@ GITPATH="$PLUGINDIR/" # this file should be in the base of your git repository
 
 # Let's begin...
 echo ".........................................."
-echo 
+echo
 echo "Preparing to deploy WordPress plugin"
-echo 
+echo
 echo ".........................................."
-echo 
+echo
 
 # Check version in readme.txt is the same as plugin file after translating both to unix line breaks to work around grep's failure to identify mac line breaks
 PLUGINVERSION=`grep "Version:" $GITPATH/$MAINFILE | awk -F' ' '{print $NF}' | tr -d '\r'`
@@ -100,9 +100,9 @@ fi
 
 # GaryJ: Ignore check for git tag, as git flow release finish creates this.
 #if git show-ref --tags --quiet --verify -- "refs/tags/$PLUGINVERSION"
-#	then 
-#		echo "Version $PLUGINVERSION already exists as git tag. Exiting...."; 
-#		exit 1; 
+#	then
+#		echo "Version $PLUGINVERSION already exists as git tag. Exiting....";
+#		exit 1;
 #	else
 #		echo "Git version does not exist. Let's proceed..."
 #fi
@@ -123,7 +123,7 @@ echo "Pushing git master to origin, with tags"
 git push origin master
 git push origin master --tags
 
-echo 
+echo
 echo "Creating local copy of SVN repo trunk ..."
 svn checkout $SVNURL $SVNPATH --depth immediates
 svn update --quiet $SVNPATH/trunk --set-depth infinity


### PR DESCRIPTION
As the parser may timeout if the readme.txt becomes too large, it would be useful to not exclude the CHANGELOG.md

https://wordpress.slack.com/archives/meta/p1466510210000492

Also removes some trailing spaces.