### PR TITLE
Y/n question case insensensitivity

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -70,7 +70,7 @@ PROCEED="${input:-y}"
 echo
 
 # Allow user cancellation
-if [ "$PROCEED" != "y" ]; then echo "Aborting..."; exit 1; fi
+if [ $(echo "$PROCEED" |tr [:upper:] [:lower:]) != "y" ]; then echo "Aborting..."; exit 1; fi
 
 # git config
 GITPATH="$PLUGINDIR/" # this file should be in the base of your git repository


### PR DESCRIPTION
The prompt says `Y|n`, but it expects `y`.  This makes the input case insensitive so that `Y` or `y` both mean Yes. 

Inspired by http://www.unix.com/302615169-post5.html

Tested on `GNU bash, version 4.4.12(1)-release (x86_64-apple-darwin16.3.0)`